### PR TITLE
Collect information on segment and function coverage over time.

### DIFF
--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -332,8 +332,7 @@ def get_coverage_binary(benchmark: str) -> str:
 
 
 def get_trial_ids(experiment: str, fuzzer: str, benchmark: str):
-    """Gets ids of all finished trials for a pair of
-    fuzzer and benchmark."""
+    """Gets ids of all finished trials for a pair of fuzzer and benchmark."""
     trial_ids = [
         trial_id_tuple[0]
         for trial_id_tuple in db_utils.query(models.Trial.id).filter(

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -64,29 +64,20 @@ def generate_coverage_reports(experiment_config: dict,
     logger.info('Finished generating coverage reports.')
 
 
-def create_empty_dataframe_container():
-    """Helper function to create experiment specific data frames"""
-    segment_df = pd.DataFrame(columns=[
-        "benchmark", "fuzzer", "trial_id", "file_name", "line", "col",
-        "time_stamp"
-    ])
-    function_df = pd.DataFrame(columns=[
-        "benchmark", "fuzzer", "trial_id", "function_name", "hits", "time_stamp"
-    ])
-    name_df = pd.DataFrame(columns=['id', 'name', 'type'])
-
-    df_container = DataFrameContainer(segment_df, function_df, name_df)
-    return df_container
-
-
 class DataFrameContainer:
     """ Holds experiment-specific segment and function coverage information for
     all fuzzers, benchmarks, and trials"""
 
-    def __init__(self, segment_df, function_df, name_df):
-        self.segment_df = segment_df
-        self.function_df = function_df
-        self.name_df = name_df
+    def __init__(self):
+        self.segment_df = pd.DataFrame(columns=[
+            "benchmark", "fuzzer", "trial_id", "file_name", "line", "col",
+            "time_stamp"
+        ])
+        self.function_df = pd.DataFrame(columns=[
+            "benchmark", "fuzzer", "trial_id", "function_name", "hits",
+            "time_stamp"
+        ])
+        self.name_df = pd.DataFrame(columns=['id', 'name', 'type'])
 
     def prepare_name_dataframe(self):
         """Populates name data frame with experiment specific benchmark names,
@@ -400,7 +391,7 @@ def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-man
     # multiple processes while measuring. So each process returns a
     # process-specific data frame container with all the information collected
     # in that particular process
-    process_specific_df_container = create_empty_dataframe_container()
+    process_specific_df_container = DataFrameContainer()
 
     try:
         coverage_info = get_coverage_infomation(summary_json_file)

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -42,7 +42,8 @@ def get_coverage_info_dir():
     return os.path.join(work_dir, 'coverage')
 
 
-def generate_coverage_reports(experiment_config: dict, df_container):
+def generate_coverage_reports(experiment_config: dict,
+                              experiment_specific_df_container):
     """Generates coverage reports for each benchmark and fuzzer."""
     logs.initialize()
     logger.info('Start generating coverage reports.')
@@ -54,11 +55,28 @@ def generate_coverage_reports(experiment_config: dict, df_container):
     for benchmark in benchmarks:
         for fuzzer in fuzzers:
             generate_coverage_report(experiment, benchmark, fuzzer)
+
+    # Clean and prune experiment-specific data frames
+    experiment_specific_df_container.prepare_name_dataframe()
+    experiment_specific_df_container.remove_redundant_duplicates()
     # Generate experiment-specific CSV files
-    prepare_name_dataframe(df_container)
-    remove_redundant_duplicates(df_container)
-    generate_segment_and_function_csv_files(df_container)
+    generate_segment_and_function_csv_files(experiment_specific_df_container)
     logger.info('Finished generating coverage reports.')
+
+
+def create_empty_dataframe_container():
+    """Helper function to create experiment specific data frames"""
+    segment_df = pd.DataFrame(columns=[
+        "benchmark", "fuzzer", "trial_id", "file_name", "line", "col",
+        "time_stamp"
+    ])
+    function_df = pd.DataFrame(columns=[
+        "benchmark", "fuzzer", "trial_id", "function_name", "hits", "time_stamp"
+    ])
+    name_df = pd.DataFrame(columns=['id', 'name', 'type'])
+
+    df_container = DataFrameContainer(segment_df, function_df, name_df)
+    return df_container
 
 
 class DataFrameContainer:
@@ -69,6 +87,93 @@ class DataFrameContainer:
         self.segment_df = segment_df
         self.function_df = function_df
         self.name_df = name_df
+
+    def prepare_name_dataframe(self):
+        """Populates name data frame with experiment specific benchmark names,
+        fuzzer names, file names and function names and also replaces names with
+        ids in segment and function data frames."""
+        try:
+            # Stack all names into a single numpy array.
+            names = np.hstack([
+                self.segment_df['benchmark'].unique(),
+                self.segment_df['fuzzer'].unique(),
+                self.function_df['function_name'].unique(),
+                self.segment_df['file_name'].unique()
+            ])
+
+            # Create a list with "type" of names to match the stack above.
+            types = ['benchmark'] * len(self.segment_df['benchmark'].unique())
+            types.extend(['fuzzer'] * len(self.segment_df['fuzzer'].unique()))
+            types.extend(['function'] *
+                         len(self.function_df['function_name'].unique()))
+            types.extend(['file'] * len(self.segment_df['file_name'].unique()))
+
+            # Populate name DataFrame.
+            self.name_df['name'] = names
+            self.name_df['type'] = types
+            self.name_df.reset_index()
+            self.name_df['id'] = self.name_df.index + 1
+
+            # Reshape DataFrames for joins.
+            reshaped_name_df = self.name_df.pivot(index='name',
+                                                  columns='type',
+                                                  values='id')
+            # making "name" as a column again
+            reshaped_name_df['name'] = reshaped_name_df.index
+
+            # Replacing names with ids by joining DataFrames.
+            self.segment_df = self.rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
+
+            self.function_df = self.rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
+
+            self.segment_df = self.rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df,
+                ['benchmark', 'benchmark_id'])
+
+            self.function_df = self.rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df,
+                ['benchmark', 'benchmark_id'])
+
+            self.segment_df = self.rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df, ['file_name', 'file_id'])
+
+            self.function_df = self.rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df,
+                ['function_name', 'function_id'])
+
+        except (ValueError, KeyError, IndexError):
+            logger.error('Error occurred when preparing name DataFrame.')
+
+    def rename_drop_columns_and_leftjoin(self, df1, df2, name_list):  # pylint: disable=no-self-use
+        """Helper function to rename data frame df2 and merge data frame df1 and
+        df2 on a given column."""
+        column_name = name_list[0]
+        df2.columns = [
+            'benchmark_id', 'file_id', 'function_id', 'fuzzer_id', column_name
+        ]
+        # Select columns to drop.
+        cols = [col for col in df2.columns if col not in name_list]
+        # Lef-join action.
+        df = pd.merge(df1, df2.drop(columns=cols), on=column_name, how='outer')
+        # Drop unnecessary columns.
+        df = df.drop(columns=[column_name])
+        return df.dropna()
+
+    def remove_redundant_duplicates(self):
+        """Removes entries with same segment coverage information but different
+        timestamps (keeps the data with smallest timestamp (in secs)). Also
+        removes redundant rows from function data frame, if any, to reduce the
+        size of the data being exported"""
+        try:
+            # Drop duplicates but with different timestamps in segment data.
+            self.segment_df = self.segment_df.sort_values(by=['time_stamp'])
+            self.segment_df = self.segment_df.drop_duplicates(
+                subset=self.segment_df.columns.difference(['time_stamp']),
+                keep="first")
+        except (ValueError, KeyError, IndexError):
+            logger.error('Error occurred when removing duplicates.')
 
 
 def generate_coverage_report(experiment, benchmark, fuzzer):
@@ -289,25 +394,28 @@ def generate_json_summary(coverage_binary,
 
 def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-many-locals
         summary_json_file, benchmark, fuzzer, trial_id, time_stamp):
-    """Extracts and stores information on segment and function coverage for a
-    trial in experiment-specific data frames given a trial-specific coverage
-    summary json file."""
-    # Create dummy data frames for recording segment and function. These
-    # data frames would be concatenated to the main experiment specific
-    # data frames after recording all segment and function coverage data.
-    segment_df, function_df = create_experiment_specific_data_frames(
-        dummies=True)
+    """Return a process-specific data frame with segment and function coverage
+    information given a trial-specific coverage summary json file."""
+    # Create process specific data frame container as this function is called by
+    # multiple processes while measuring. So each process returns a
+    # process-specific data frame container with all the information collected
+    # in that particular process
+    process_specific_df_container = create_empty_dataframe_container()
+
     try:
         coverage_info = get_coverage_infomation(summary_json_file)
-
         # Extract coverage information for functions.
         for function_data in coverage_info['data'][0]['functions']:
             to_append = [
                 benchmark, fuzzer, trial_id, function_data['name'],
                 function_data['count'], time_stamp
             ]
-            series = pd.Series(to_append, index=function_df.columns)
-            function_df = function_df.append(series, ignore_index=True)
+            series = pd.Series(
+                to_append,
+                index=process_specific_df_container.function_df.columns)
+            process_specific_df_container.function_df = (
+                process_specific_df_container.function_df.append(
+                    series, ignore_index=True))
 
         # Extract coverage information for functions and segments.
         line_index = 0
@@ -321,13 +429,17 @@ def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-man
                         benchmark, fuzzer, trial_id, filename,
                         segment[line_index], segment[col_index], time_stamp
                     ]
-                    series = pd.Series(to_append, index=segment_df.columns)
-                    segment_df = segment_df.append(series, ignore_index=True)
+                    series = pd.Series(
+                        to_append,
+                        index=process_specific_df_container.segment_df.columns)
+                    process_specific_df_container.segment_df = (
+                        process_specific_df_container.segment_df.append(
+                            series, ignore_index=True))
 
     except (ValueError, KeyError, IndexError):
         logger.error('Failed when extracting trial-specific segment and'
                      'function information from coverage summary')
-    return segment_df, function_df
+    return process_specific_df_container
 
 
 def extract_covered_regions_from_summary_json(summary_json_file):
@@ -355,85 +467,6 @@ def extract_covered_regions_from_summary_json(summary_json_file):
     return covered_regions
 
 
-def prepare_name_dataframe(df_container):
-    """Populates name data frame with experiment specific benchmark names,
-    fuzzer names, file names and function names and also replaces names with ids
-    in segment and function data frames."""
-    try:
-        # Stack all names into a single numpy array.
-        names = np.hstack([
-            df_container.segment_df['benchmark'].unique(),
-            df_container.segment_df['fuzzer'].unique(),
-            df_container.function_df['function_name'].unique(),
-            df_container.segment_df['file_name'].unique()
-        ])
-
-        # Create a list with "type" of names to match the stack above.
-        types = ['benchmark'] * len(
-            df_container.segment_df['benchmark'].unique())
-        types.extend(['fuzzer'] *
-                     len(df_container.segment_df['fuzzer'].unique()))
-        types.extend(['function'] *
-                     len(df_container.function_df['function_name'].unique()))
-        types.extend(['file'] *
-                     len(df_container.segment_df['file_name'].unique()))
-
-        # Populate name DataFrame.
-        df_container.name_df['name'] = names
-        df_container.name_df['type'] = types
-        df_container.name_df.reset_index()
-        df_container.name_df['id'] = df_container.name_df.index + 1
-
-        # Reshape DataFrames for joins.
-        reshaped_name_df = df_container.name_df.pivot(index='name',
-                                                      columns='type',
-                                                      values='id')
-        # making "name" as a column again
-        reshaped_name_df['name'] = reshaped_name_df.index
-
-        # Replacing names with ids by joining DataFrames.
-        df_container.segment_df = rename_drop_columns_and_leftjoin(
-            df_container.segment_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
-
-        df_container.function_df = rename_drop_columns_and_leftjoin(
-            df_container.function_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
-
-        df_container.segment_df = rename_drop_columns_and_leftjoin(
-            df_container.segment_df, reshaped_name_df,
-            ['benchmark', 'benchmark_id'])
-
-        df_container.function_df = rename_drop_columns_and_leftjoin(
-            df_container.function_df, reshaped_name_df,
-            ['benchmark', 'benchmark_id'])
-
-        df_container.segment_df = rename_drop_columns_and_leftjoin(
-            df_container.segment_df, reshaped_name_df, ['file_name', 'file_id'])
-
-        df_container.function_df = rename_drop_columns_and_leftjoin(
-            df_container.function_df, reshaped_name_df,
-            ['function_name', 'function_id'])
-
-    except (ValueError, KeyError, IndexError):
-        logger.error('Error occurred when preparing name DataFrame.')
-
-
-def remove_redundant_duplicates(df_container):
-    """Removes entries with same segment coverage information but different
-    timestamps (keeps the data with smallest timestamp (in secs)). Also removes
-    redundant rows from function data frame, if any, to reduce the size of the
-    data being exported"""
-    try:
-        # Drop duplicates but with different timestamps in segment data.
-        df_container.segment_df = df_container.segment_df.sort_values(
-            by=['time_stamp'])
-        df_container.segment_df = df_container.segment_df.drop_duplicates(
-            subset=df_container.segment_df.columns.difference(['time_stamp']),
-            keep="first")
-
-    except (ValueError, KeyError, IndexError):
-        logger.error('Error occurred when removing duplicates.')
-
-
 def generate_segment_and_function_csv_files(df_container):
     """Generates three compressed CSV files containing coverage information for
     all fuzzers, benchmarks, and trials. To maintain a small file size, all
@@ -443,7 +476,7 @@ def generate_segment_and_function_csv_files(df_container):
     csv_filestore_helper('functions.csv.gz', df_container.function_df)
 
     # Store compressed (gzip) segment csv in filestore.
-    csv_filestore_helper('segment.csv.gz', df_container.segment_df)
+    csv_filestore_helper('segments.csv.gz', df_container.segment_df)
 
     # Store compressed (gzip) names csv in filestore.
     csv_filestore_helper('names.csv.gz', df_container.name_df)
@@ -455,42 +488,3 @@ def csv_filestore_helper(file_name, df):
     dst = exp_path.filestore(src)
     df.to_csv(src, index=False, compression='infer')
     filestore_utils.cp(src, dst)
-
-
-def rename_drop_columns_and_leftjoin(df1, df2, name_list):
-    """Helper function to rename data frame df2 and merge data frame df1 and df2
-    on a given column."""
-    column_name = name_list[0]
-    df2.columns = [
-        'benchmark_id', 'file_id', 'function_id', 'fuzzer_id', column_name
-    ]
-    # Select columns to drop.
-    cols = [col for col in df2.columns if col not in name_list]
-    # Lef-join action.
-    df = pd.merge(df1, df2.drop(columns=cols), on=column_name, how='outer')
-    # Drop unnecessary columns.
-    df = df.drop(columns=[column_name])
-    return df.dropna()
-
-
-def create_experiment_specific_data_frames(dummies: bool):
-    """Helper function to create experiment specific data frames. It also allows
-    creation of dummies data frames with same header to collect data and append
-    to he main data frame. Avoids declaration of data frames anywhere again."""
-    segment_df = pd.DataFrame(columns=[
-        "benchmark", "fuzzer", "trial_id", "file_name", "line", "col",
-        "time_stamp"
-    ])
-    function_df = pd.DataFrame(columns=[
-        "benchmark", "fuzzer", "trial_id", "function_name", "hits", "time_stamp"
-    ])
-    name_df = pd.DataFrame(columns=['id', 'name', 'type'])
-    # If creating dummies for easy appending and concatenation then, only
-    # segment and function data frames are returned
-    if dummies:
-        return segment_df, function_df
-
-    # If not creating dummies then, all the experiment specific data frames are
-    # returned as DataFrameContainer object together
-    df_container = DataFrameContainer(segment_df, function_df, name_df)
-    return df_container

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -36,8 +36,8 @@ COV_DIFF_QUEUE_GET_TIMEOUT = 1
 
 
 def get_coverage_info_dir():
-    """Returns the directory to store coverage information including
-    coverage report and json summary file."""
+    """Returns the directory to store coverage information including coverage
+    report and json summary file."""
     work_dir = exp_utils.get_work_dir()
     return os.path.join(work_dir, 'coverage')
 
@@ -108,7 +108,7 @@ class DataFrameContainer:
             reshaped_name_df['name'] = reshaped_name_df.index
 
             # Helper function to rename, drop, and leftjoin in bulk.
-            def rename_drop_columns_and_leftjoin(df1, df2, name_list):  # pylint: disable=no-self-use
+            def rename_drop_columns_and_leftjoin(df1, df2, name_list):
                 column_name = name_list[0]
                 df2.columns = [
                     'benchmark_id', 'file_id', 'function_id', 'fuzzer_id',
@@ -149,11 +149,11 @@ class DataFrameContainer:
 
     def remove_redundant_duplicates(self):
         """Removes redundant entries in segment_df. Before calling this
-        function, for each time stamp, segment_df contains all segments that
-        are covered in this time stamp. After calling this function, for each
-        time stamp, segment_df only contains segments that have been covered
-        since the previous time stamp. This signifcantly reduces the size of
-        the resulting CSV file."""
+        function, for each time stamp, segment_df contains all segments that are
+        covered in this time stamp. After calling this function, for each time
+        stamp, segment_df only contains segments that have been covered since
+        the previous time stamp. This significantly reduces the size of the
+        resulting CSV file."""
         try:
             # Drop duplicates but with different timestamps in segment data.
             self.segment_df = self.segment_df.sort_values(by=['time_stamp'])
@@ -214,8 +214,8 @@ def generate_coverage_report(experiment, benchmark, fuzzer):
 
 
 class CoverageReporter:  # pylint: disable=too-many-instance-attributes
-    """Class used to generate coverage report for a pair of
-    fuzzer and benchmark."""
+    """Class used to generate coverage report for a pair of fuzzer and
+    benchmark."""
 
     # pylint: disable=too-many-arguments
     def __init__(self, experiment, fuzzer, benchmark):
@@ -332,7 +332,8 @@ def get_coverage_binary(benchmark: str) -> str:
 
 
 def get_trial_ids(experiment: str, fuzzer: str, benchmark: str):
-    """Gets ids of all finished trials for a pair of fuzzer and benchmark."""
+    """Gets ids of all finished trials for a pair of
+    fuzzer and benchmark."""
     trial_ids = [
         trial_id_tuple[0]
         for trial_id_tuple in db_utils.query(models.Trial.id).filter(

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -68,8 +68,7 @@ def measure_main(experiment_config):
 
     # Create experiment specific data frames for recording segment and function
     # data over time
-    experiment_specific_df_container = (
-        coverage_utils.create_empty_dataframe_container())
+    experiment_specific_df_container = coverage_utils.DataFrameContainer()
 
     # Start the measure loop first.
     experiment = experiment_config['experiment']
@@ -718,8 +717,7 @@ def main():
 
     # Create experiment specific data frames for recording segment and function
     # data over time
-    experiment_specific_df_container = (
-        coverage_utils.create_empty_dataframe_container())
+    experiment_specific_df_container = coverage_utils.DataFrameContainer()
 
     try:
         measure_loop(experiment_name, int(sys.argv[1]),

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -66,7 +66,7 @@ def measure_main(experiment_config):
     initialize_logs()
     logger.info('Start measuring.')
 
-    # Create data frame contaienr for segment and function coverage info.
+    # Create data frame container for segment and function coverage info.
     experiment_specific_df_container = coverage_utils.DataFrameContainer()
 
     # Start the measure loop first.
@@ -78,8 +78,10 @@ def measure_main(experiment_config):
     gc.collect()
 
     # Do the final measuring and store the coverage data.
-    coverage_utils.generate_coverage_reports(experiment_config,
-                                             experiment_specific_df_container)
+    coverage_utils.generate_coverage_reports(experiment_config)
+
+    # Generate segment and function coverage CSV files.
+    experiment_specific_df_container.generate_csv_files()
 
     logger.info('Finished measuring.')
 
@@ -567,10 +569,10 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
             snapshot, process_specific_df_container = measure_snapshot_coverage(
                 measure_req.fuzzer, measure_req.benchmark, measure_req.trial_id,
                 cycle)
-            # Append the process-specific data frames to respective
-            # multiprocessing list.
+
             segment_list.append(process_specific_df_container.segment_df)
             function_list.append(process_specific_df_container.function_df)
+
             if not snapshot:
                 break
             q.put(snapshot)

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -99,10 +99,10 @@ def measure_loop(experiment: str, max_total_time: int,
 
         # Use multiprocess list to collect information on segment and function
         # coverage from all processes.
-        segment_list = manager.list(
+        segment_list = manager.list(  # pytype: disable=attribute-error
             [experiment_specific_df_container.segment_df])
 
-        function_list = manager.list(
+        function_list = manager.list(  # pytype: disable=attribute-error
             [experiment_specific_df_container.function_df])
         while True:
             try:
@@ -559,8 +559,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
 def measure_trial_coverage(  # pylint: disable=invalid-name
         measure_req, max_cycle: int, q: multiprocessing.Queue, segment_list,
-        function_list
-) -> Tuple[models.Snapshot, coverage_utils.DataFrameContainer]:
+        function_list):
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()

--- a/experiment/test_coverage_utils.py
+++ b/experiment/test_coverage_utils.py
@@ -36,9 +36,7 @@ def test_extract_segments_and_functions_from_summary_json(fs):
     trial_id = 2  # for testing
     timestamp = 900
 
-    df_container = coverage_utils.create_experiment_specific_data_frames(
-        dummies=False)
-    df_container.segment_df, df_container.function_df = (
+    df_container = (
         coverage_utils.extract_segments_and_functions_from_summary_json(
             summary_json_file, benchmark, fuzzer, trial_id, timestamp))
 
@@ -59,12 +57,11 @@ def test_prepare_name_dataframes(fs):
     function_name_test_cov_summary = ['main', '_Z3fooIiEvT_', '_Z3fooIfEvT_']
     filename_test_cov_summary = ['/home/test/fuzz_no_fuzzer.cc']
 
-    df_container = coverage_utils.create_experiment_specific_data_frames(
-        dummies=False)
-    df_container.segment_df, df_container.function_df = (
+    df_container = (
         coverage_utils.extract_segments_and_functions_from_summary_json(
             summary_json_file, benchmark, fuzzer, trial_id, timestamp))
-    coverage_utils.prepare_name_dataframe(df_container)
+
+    df_container.prepare_name_dataframe()
 
     for func_id in list(df_container.function_df['function_id'].unique()):
         assert (df_container.name_df.loc[df_container.name_df['id'] ==

--- a/experiment/test_coverage_utils.py
+++ b/experiment/test_coverage_utils.py
@@ -14,7 +14,6 @@
 """Tests for coverage_utils.py"""
 import os
 
-import pandas as pd
 from experiment import coverage_utils
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'test_data')
@@ -35,14 +34,16 @@ def test_extract_segments_and_functions_from_summary_json(fs):
     benchmark = 'freetype2'  # for testing
     fuzzer = 'afl'  # for testing
     trial_id = 2  # for testing
-    timestamp = "10 OCT 2020 10:10:10"
+    timestamp = 900
 
-    segment_df, function_df = (
+    df_container = coverage_utils.create_experiment_specific_data_frames(
+        dummies=False)
+    df_container.segment_df, df_container.function_df = (
         coverage_utils.extract_segments_and_functions_from_summary_json(
             summary_json_file, benchmark, fuzzer, trial_id, timestamp))
 
-    assert len(segment_df) == num_covered_segments_in_cov_summary
-    assert len(function_df) == num_functions_in_cov_summary
+    assert len(df_container.segment_df) == num_covered_segments_in_cov_summary
+    assert len(df_container.function_df) == num_functions_in_cov_summary
 
 
 def test_prepare_name_dataframes(fs):
@@ -54,20 +55,15 @@ def test_prepare_name_dataframes(fs):
     benchmark = 'freetype2'  # for testing
     fuzzer = 'afl'  # for testing
     trial_id = 2  # for testing
+    timestamp = "900"
     function_name_test_cov_summary = ['main', '_Z3fooIiEvT_', '_Z3fooIfEvT_']
     filename_test_cov_summary = ['/home/test/fuzz_no_fuzzer.cc']
 
-    segment_df = pd.DataFrame(
-        columns=["benchmark", "fuzzer", "trial_id", "file_name", "line", "col"])
-    function_df = pd.DataFrame(
-        columns=["benchmark", "fuzzer", "trial_id", "function_name", "hits"])
-    name_df = pd.DataFrame(columns=['id', 'name', 'type'])
-
-    df_container = coverage_utils.DataFrameContainer(segment_df, function_df,
-                                                     name_df)
+    df_container = coverage_utils.create_experiment_specific_data_frames(
+        dummies=False)
     df_container.segment_df, df_container.function_df = (
         coverage_utils.extract_segments_and_functions_from_summary_json(
-            summary_json_file, benchmark, fuzzer, trial_id, df_container))
+            summary_json_file, benchmark, fuzzer, trial_id, timestamp))
     coverage_utils.prepare_name_dataframe(df_container)
 
     for func_id in list(df_container.function_df['function_id'].unique()):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -418,7 +418,7 @@ class TestIntegrationMeasurement:
             mocked_cp.return_value = new_process.ProcessResult(0, '', False)
             # TODO(metzman): Create a system for using actual buckets in
             # integration tests.
-            snapshot, df1, df2 = measurer.measure_snapshot_coverage(  # pylint: disable=unused-variable
+            snapshot, _, __ = measurer.measure_snapshot_coverage(  # pylint: disable=unused-variable
                 snapshot_measurer.fuzzer, snapshot_measurer.benchmark,
                 snapshot_measurer.trial_num, cycle)
         assert snapshot
@@ -446,6 +446,7 @@ def test_extract_corpus(archive_name, tmp_path):
 @mock.patch('multiprocessing.Manager')
 @mock.patch('multiprocessing.pool')
 @mock.patch('experiment.scheduler.all_trials_ended', return_value=True)
+@mock.patch('experiment.measurer.lists_are_empty', return_value=True)
 def test_measure_loop_end(_, __, ___, ____, _____, ______, experiment_config,
                           db_experiment):
     """Tests that measure_loop stops when there is nothing left to measure. In

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -19,7 +19,6 @@ from unittest import mock
 import queue
 
 import pytest
-import pandas as pd
 
 from common import experiment_utils
 from common import new_process
@@ -43,19 +42,6 @@ GIT_HASH = 'FAKE-GIT-HASH'
 CYCLE = 1
 
 SNAPSHOT_LOGGER = measurer.logger
-
-SEGMENT_DF = pd.DataFrame(columns=[
-    "benchmark", "fuzzer", "trial_id", "file_name", "line", "col", "timestamp"
-])
-
-FUNCTION_DF = pd.DataFrame(columns=[
-    "benchmark", "fuzzer", "trial_id", "function_name", "hits", "timestamp"
-])
-
-NAME_DF = pd.DataFrame(columns=['id', 'name', 'type'])
-
-DF_CONTAINER = coverage_utils.DataFrameContainer(SEGMENT_DF, FUNCTION_DF,
-                                                 NAME_DF)
 
 
 # pylint: disable=unused-argument,invalid-name,redefined-outer-name,protected-access
@@ -451,8 +437,8 @@ def test_measure_loop_end(_, __, ___, ____, _____, ______, experiment_config,
                           db_experiment):
     """Tests that measure_loop stops when there is nothing left to measure. In
     this test, there is nothing left to measure on the first call."""
-    global DF_CONTAINER
-    measurer.measure_loop(experiment_config, 100, DF_CONTAINER)
+    measurer.measure_loop(experiment_config, 100,
+                          coverage_utils.DataFrameContainer())
     # If everything went well, we should get to this point without any
     # exceptions.
 
@@ -483,7 +469,8 @@ def test_measure_loop_loop_until_end(mocked_measure_all_trials, _, __, ___,
         return True
 
     mocked_measure_all_trials.side_effect = mock_measure_all_trials
-    measurer.measure_loop(experiment_config, 100, DF_CONTAINER)
+    measurer.measure_loop(experiment_config, 100,
+                          coverage_utils.DataFrameContainer())
     assert call_count == loop_iterations
 
 


### PR DESCRIPTION
Collecting segment and function coverage information at an interval of 900 seconds when the snapshots for each benchmark-fuzzer-trial combinations are being measured.

Finally, 3 compressed csvs with coverage information are generated, namely, segment.csv.gz, functions.csv.gz & names.csv.gz.