### PR TITLE
fix linter error

### DIFF
--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -138,7 +138,8 @@ def measure_all_trials(  # pylint: disable=too-many-arguments,too-many-locals
     if not unmeasured_snapshots:
         return False
 
-    process_specific_df_containers = manager.list()  # pytype: disable=attribute-error
+    process_specific_df_containers = \
+        manager.list()  # pytype: disable=attribute-error
 
     measure_trial_coverage_args = [
         (unmeasured_snapshot, max_cycle, q, process_specific_df_containers)


### PR DESCRIPTION
Fixing pytest annotation (line-too-long).