### PR TITLE
[PR with same name but NEW] Generating segment and function coverage over time.

### DIFF
--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility functions for coverage report generation."""
-
+import hashlib
 import os
 import json
+import pandas as pd
 
 from common import experiment_path as exp_path
 from common import experiment_utils as exp_utils
@@ -54,6 +55,130 @@ def generate_coverage_reports(experiment_config: dict):
             generate_coverage_report(experiment, benchmark, fuzzer)
 
     logger.info('Finished generating coverage reports.')
+
+
+class DataFrameContainer:  # pylint: disable=too-many-instance-attributes
+    """Maintains segment and function coverage information, and writes this
+    information to CSV files."""
+
+    def __init__(self):
+        """Constructor"""
+        self.segment_entries = []
+        self.function_entries = []
+        self.fuzzer_names = dict()
+        self.benchmark_names = dict()
+        self.function_names = dict()
+        self.file_names = dict()
+        # Will be initialized upon done_adding_entries().
+        self.segment_df = None
+        self.function_df = None
+        self.name_df = None
+
+    def add_function_entry(self, benchmark, fuzzer, trial_id, function,
+                           function_hits, time):
+        # pylint: disable=too-many-arguments
+        """Adds an entry to the function_df."""
+        fuzzer_id = self.name_to_id(fuzzer)
+        benchmark_id = self.name_to_id(benchmark)
+        function_id = self.name_to_id(function)
+        self.fuzzer_names[fuzzer] = fuzzer_id
+        self.benchmark_names[benchmark] = benchmark_id
+        self.function_names[function] = function_id
+
+        function_entry = [
+            benchmark_id, fuzzer_id, trial_id, time, function_id, function_hits
+        ]
+        self.function_entries.append(function_entry)
+
+    def add_segment_entry(self, benchmark, fuzzer, trial_id, file_name, line,
+                          column, time):
+        # pylint: disable=too-many-arguments
+        """Adds an entry to the segment_df."""
+        fuzzer_id = self.name_to_id(fuzzer)
+        benchmark_id = self.name_to_id(benchmark)
+        file_id = self.name_to_id(file_name)
+        self.fuzzer_names[fuzzer] = fuzzer_id
+        self.benchmark_names[benchmark] = benchmark_id
+        self.file_names[file_name] = file_id
+
+        segment_entry = [
+            benchmark_id, fuzzer_id, trial_id, time, file_id, line, column
+        ]
+        self.segment_entries.append(segment_entry)
+
+    def done_adding_entries(self):
+        """Generates the data frames from the individual entries."""
+
+        if len(self.segment_entries) == 0:
+            logger.error('Finalizing, but no entries were added.')
+            return
+
+        self.segment_df = pd.DataFrame(self.segment_entries,
+                                       columns=[
+                                           "benchmark", "fuzzer", "trial",
+                                           "time", "file", "line", "column"
+                                       ])
+        self.function_df = pd.DataFrame(self.function_entries,
+                                        columns=[
+                                            "benchmark", "fuzzer", "trial",
+                                            "time", "function", "hits"
+                                        ])
+
+        name_entries = []
+        for name in self.benchmark_names:
+            name_entries.append([self.benchmark_names[name], name, "benchmark"])
+        for name in self.fuzzer_names:
+            name_entries.append([self.fuzzer_names[name], name, "fuzzer"])
+        for name in self.function_names:
+            name_entries.append([self.function_names[name], name, "function"])
+        for name in self.file_names:
+            name_entries.append([self.file_names[name], name, "file"])
+        self.name_df = pd.DataFrame(name_entries,
+                                    columns=["id", "name", "type"])
+
+    def name_to_id(self, name):  # pylint: disable=no-self-use
+        """Generates a hash for the name. This is to save disk storage"""
+        return hashlib.md5(name.encode()).hexdigest()[:7]
+
+    def remove_redundant_duplicates(self):
+        """Removes redundant entries in segment_df. Before calling this
+        function, for each time stamp, segment_df contains all segments that are
+        covered in this time stamp. After calling this function, for each time
+        stamp, segment_df only contains segments that have been covered since
+        the previous time stamp. This significantly reduces the size of the
+        resulting CSV file."""
+        try:
+            # Drop duplicates but with different timestamps in segment data.
+            self.segment_df = self.segment_df.sort_values(by=['time'])
+            self.segment_df = self.segment_df.drop_duplicates(
+                subset=self.segment_df.columns.difference(['time']),
+                keep="first")
+            self.name_df = self.name_df.drop_duplicates(keep="first")
+
+        except (ValueError, KeyError, IndexError):
+            logger.error('Error occurred when removing duplicates.')
+
+    def generate_csv_files(self):
+        """Generates three compressed CSV files containing coverage information
+        for all fuzzers, benchmarks, and trials. To maintain a small file size,
+        all strings, such as file and function names, are referenced by id and
+        resolved in 'names.csv'."""
+
+        # Clean and prune experiment-specific data frames.
+        self.remove_redundant_duplicates()
+
+        # Write CSV files to file store.
+        def csv_filestore_helper(file_name, df):
+            """Helper function for storing csv files in filestore."""
+            src = os.path.join(get_coverage_info_dir(), 'data', file_name)
+            dst = exp_path.filestore(src)
+            df.to_csv(src, index=False, compression='infer')
+            filestore_utils.cp(src, dst)
+
+        logger.info('Generating CSV Files.')
+        csv_filestore_helper('functions.csv.gz', self.function_df)
+        csv_filestore_helper('segments.csv.gz', self.segment_df)
+        csv_filestore_helper('names.csv.gz', self.name_df)
 
 
 def generate_coverage_report(experiment, benchmark, fuzzer):
@@ -267,6 +392,43 @@ def generate_json_summary(coverage_binary,
                                      output_file=dst_file,
                                      expect_zero=False)
     return result
+
+
+def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-many-locals
+        summary_json_file, benchmark, fuzzer, trial_id, time):
+    """Return a trial-specific data frame container with segment and function
+     coverage information given a trial-specific coverage summary json file."""
+
+    process_specific_df_container = DataFrameContainer()
+
+    try:
+        coverage_info = get_coverage_infomation(summary_json_file)
+        # Extract coverage information for functions.
+        for function_data in coverage_info['data'][0]['functions']:
+            process_specific_df_container.add_function_entry(
+                benchmark, fuzzer, trial_id, function_data['name'],
+                function_data['count'], time)
+
+        # Extract coverage information for segments.
+        for file in coverage_info['data'][0]['files']:
+            for segment in file['segments']:
+                if segment[2] != 0:  # Segment hits.
+                    process_specific_df_container.add_segment_entry(
+                        benchmark,
+                        fuzzer,
+                        trial_id,
+                        file['filename'],
+                        segment[0],  # Segment line.
+                        segment[1],  # Segment column.
+                        time)
+
+    except (ValueError, KeyError, IndexError):
+        logger.error('Failed when extracting trial-specific segment and'
+                     'function information from coverage summary')
+
+    process_specific_df_container.done_adding_entries()
+
+    return process_specific_df_container
 
 
 def extract_covered_regions_from_summary_json(summary_json_file):

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -380,7 +380,8 @@ def generate_json_summary(coverage_binary,
     """Generates the json summary file from |coverage_binary|
     and |profdata_file|."""
     command = [
-        'llvm-cov', 'export', '-format=text', coverage_binary,
+        'llvm-cov', 'export', '-format=text', '-num-threads=1',
+        '-region-coverage-gt=0', '-skip-expansions', coverage_binary,
         '-instr-profile=%s' % profdata_file
     ]
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -592,7 +592,7 @@ def get_fuzzer_stats(stats_filestore_path):
 
 def measure_trial_coverage(  # pylint: disable=invalid-name,too-many-arguments
         measure_req, max_cycle: int, q: multiprocessing.Queue,
-        process_specific_df_containers):
+        process_specific_df_containers) -> models.Snapshot:
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()

--- a/experiment/measurer/test_coverage_utils.py
+++ b/experiment/measurer/test_coverage_utils.py
@@ -24,6 +24,26 @@ def get_test_data_path(*subpaths):
     return os.path.join(TEST_DATA_PATH, *subpaths)
 
 
+def test_extract_segments_and_functions_from_summary_json(fs):
+    """Tests that extract_covered_regions_from_summary_json returns the covered
+    segments and functions from summary json file."""
+    num_functions_in_cov_summary = 3  # For testing.
+    num_covered_segments_in_cov_summary = 16  # For testing.
+    benchmark = 'freetype2'  # For testing.
+    fuzzer = 'afl'  # For testing.
+    trial_id = 2  # For testing.
+    timestamp = 900  # For testing.
+    summary_json_file = get_test_data_path('cov_summary.json')
+    fs.add_real_file(summary_json_file, read_only=False)
+
+    df_container = (
+        coverage_utils.extract_segments_and_functions_from_summary_json(
+            summary_json_file, benchmark, fuzzer, trial_id, timestamp))
+
+    assert len(df_container.segment_df) == num_covered_segments_in_cov_summary
+    assert len(df_container.function_df) == num_functions_in_cov_summary
+
+
 def test_extract_covered_regions_from_summary_json(fs):
     """Tests that extract_covered_regions_from_summary_json returns the covered
     regions from summary json file."""

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -152,7 +152,8 @@ def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
     snapshot_measurer.generate_summary(CYCLE)
 
     expected = [
-        'llvm-cov', 'export', '-format=text',
+        'llvm-cov', 'export', '-format=text', '-num-threads=1',
+        '-region-coverage-gt=0', '-skip-expansions',
         '/work/coverage-binaries/benchmark-a/fuzz-target',
         '-instr-profile=/reports/data.profdata'
     ]

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -25,7 +25,7 @@ from common import new_process
 from database import models
 from database import utils as db_utils
 from experiment.build import build_utils
-from experiment.measurer import measure_manager
+from experiment.measurer import measure_manager, coverage_utils
 from test_libs import utils as test_utils
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'test_data')
@@ -154,7 +154,7 @@ def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
     expected = [
         'llvm-cov', 'export', '-format=text',
         '/work/coverage-binaries/benchmark-a/fuzz-target',
-        '-instr-profile=/reports/data.profdata', '-summary-only'
+        '-instr-profile=/reports/data.profdata'
     ]
 
     assert (len(mocked_execute.call_args_list)) == 1
@@ -166,18 +166,21 @@ def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
 @mock.patch('common.logs.error')
 @mock.patch('experiment.measurer.measure_manager.initialize_logs')
 @mock.patch('multiprocessing.Queue')
+@mock.patch('multiprocessing.list')
 @mock.patch('experiment.measurer.measure_manager.measure_snapshot_coverage')
 def test_measure_trial_coverage(mocked_measure_snapshot_coverage, mocked_queue,
-                                _, __):
+                                _, __, mocked_process_specific_df_containers):
     """Tests that measure_trial_coverage works as expected."""
     min_cycle = 1
     max_cycle = 10
     measure_request = measure_manager.SnapshotMeasureRequest(
         FUZZER, BENCHMARK, TRIAL_NUM, min_cycle)
-    measure_manager.measure_trial_coverage(measure_request, max_cycle,
-                                           mocked_queue())
+    measure_manager.\
+        measure_trial_coverage(measure_request, max_cycle, mocked_queue(),
+                               mocked_process_specific_df_containers)
     expected_calls = [
-        mock.call(FUZZER, BENCHMARK, TRIAL_NUM, cycle)
+        mock.call(FUZZER, BENCHMARK, TRIAL_NUM, cycle,
+                  mocked_process_specific_df_containers)
         for cycle in range(min_cycle, max_cycle + 1)
     ]
     assert mocked_measure_snapshot_coverage.call_args_list == expected_calls
@@ -185,21 +188,26 @@ def test_measure_trial_coverage(mocked_measure_snapshot_coverage, mocked_queue,
 
 @mock.patch('common.filestore_utils.ls')
 @mock.patch('common.filestore_utils.rsync')
-def test_measure_all_trials_not_ready(mocked_rsync, mocked_ls, experiment):
+@mock.patch('multiprocessing.Manager')
+def test_measure_all_trials_not_ready(mocked_rsync, mocked_ls, mocked_manager,
+                                      experiment):
     """Test running measure_all_trials before it is ready works as intended."""
     mocked_ls.return_value = new_process.ProcessResult(1, '', False)
     assert measure_manager.measure_all_trials(
         experiment_utils.get_experiment_name(), MAX_TOTAL_TIME,
-        test_utils.MockPool(), queue.Queue())
+        test_utils.MockPool(), mocked_manager, queue.Queue(),
+        coverage_utils.DataFrameContainer())
     assert not mocked_rsync.called
 
 
+@mock.patch('multiprocessing.list')
 @mock.patch('multiprocessing.pool.ThreadPool', test_utils.MockPool)
 @mock.patch('common.new_process.execute')
 @mock.patch('common.filesystem.directories_have_same_files')
+@mock.patch('multiprocessing.Manager')
 @pytest.mark.skip(reason="See crbug.com/1012329")
 def test_measure_all_trials_no_more(mocked_directories_have_same_files,
-                                    mocked_execute):
+                                    mocked_execute, mocked_manager):
     """Test measure_all_trials does what is intended when the experiment is
     done."""
     mocked_directories_have_same_files.return_value = True
@@ -207,7 +215,7 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
     mock_pool = test_utils.MockPool()
     assert not measure_manager.measure_all_trials(
         experiment_utils.get_experiment_name(), MAX_TOTAL_TIME, mock_pool,
-        queue.Queue())
+        mocked_manager, queue.Queue(), coverage_utils.DataFrameContainer())
 
 
 def test_is_cycle_unchanged_doesnt_exist(experiment):
@@ -352,10 +360,12 @@ class TestIntegrationMeasurement:
     # portable binary.
     @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
                         reason='Not running integration tests.')
+    @mock.patch('multiprocessing.list')
     @mock.patch('experiment.measurer.measure_manager.SnapshotMeasurer'
                 '.is_cycle_unchanged')
-    def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
-            self, mocked_is_cycle_unchanged, db, experiment, tmp_path):
+    def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals, too-many-arguments
+            self, mocked_is_cycle_unchanged, mocked_df_container_list, db,
+            experiment, tmp_path):
         """Integration test for measure_snapshot_coverage."""
         # WORK is set by experiment to a directory that only makes sense in a
         # fakefs. A directory containing necessary llvm tools is also added to
@@ -402,7 +412,7 @@ class TestIntegrationMeasurement:
             # integration tests.
             snapshot = measure_manager.measure_snapshot_coverage(
                 snapshot_measurer.fuzzer, snapshot_measurer.benchmark,
-                snapshot_measurer.trial_num, cycle)
+                snapshot_measurer.trial_num, cycle, mocked_df_container_list)
         assert snapshot
         assert snapshot.time == cycle * experiment_utils.get_snapshot_seconds()
         assert snapshot.edges_covered == 13178
@@ -433,7 +443,8 @@ def test_measure_loop_end(_, __, ___, ____, _____, ______, experiment_config,
                           db_experiment):
     """Tests that measure_loop stops when there is nothing left to measure. In
     this test, there is nothing left to measure on the first call."""
-    measure_manager.measure_loop(experiment_config, 100)
+    measure_manager.measure_loop(experiment_config, 100,
+                                 coverage_utils.DataFrameContainer())
     # If everything went well, we should get to this point without any
     # exceptions.
 
@@ -464,7 +475,8 @@ def test_measure_loop_loop_until_end(mocked_measure_all_trials, _, __, ___,
         return True
 
     mocked_measure_all_trials.side_effect = mock_measure_all_trials
-    measure_manager.measure_loop(experiment_config, 100)
+    measure_manager.measure_loop(experiment_config, 100,
+                                 coverage_utils.DataFrameContainer())
     assert call_count == loop_iterations
 
 


### PR DESCRIPTION
So currently our implementation for the segment and function coverage has not changed, except for the directory structure. The implementation still is on top of the previous version of `scheduler` as the `queue based scheduler` is not up currently and only supports GCE experiments and that too not completely.

We can move our code once `google/fuzzbench` starts using `queue based scheduler` and have broken their measurer into workers?