### PR TITLE
changes to detailed coverage utils

### DIFF
--- a/experiment/measurer/detailed_coverage_data_utils.py
+++ b/experiment/measurer/detailed_coverage_data_utils.py
@@ -31,123 +31,61 @@ class DetailedCoverageData:  # pylint: disable=too-many-instance-attributes
 
     def __init__(self):
         """Constructor"""
-        self.segment_entries = []
-        self.function_entries = []
-        self.fuzzer_names = {}
-        self.benchmark_names = {}
-        self.function_names = {}
-        self.file_names = {}
-
         # Set by generate_data_frames_after_adding_all_entries().
-        self.segment_df = None
-        self.function_df = None
-        self.name_df = None
+        self.segment_df = pd.DataFrame(columns=[
+            'benchmark', 'fuzzer', 'trial', 'time', 'file', 'line', 'column'
+        ])
+        self.function_df = pd.DataFrame(columns=[
+            'benchmark', 'fuzzer', 'trial', 'time', 'function', 'hits'
+        ])
 
     def add_function_entry(  # pylint: disable=too-many-arguments
             self, benchmark, fuzzer, trial_id, function, function_hits, time):
         """Adds an entry to the function_df."""
-        fuzzer_id = self.name_to_id(fuzzer)
-        benchmark_id = self.name_to_id(benchmark)
-        function_id = self.name_to_id(function)
-        self.fuzzer_names[fuzzer] = fuzzer_id
-        self.benchmark_names[benchmark] = benchmark_id
-        self.function_names[function] = function_id
-
         function_entry = [
-            benchmark_id, fuzzer_id, trial_id, time, function_id, function_hits
+            benchmark, fuzzer, trial_id, time, function, function_hits
         ]
-        self.function_entries.append(function_entry)
+        insert_series = pd.Series(function_entry,
+                                  index=self.function_df.columns)
+        self.function_df = self.function_df.append(insert_series,
+                                                   ignore_index=True)
 
     def add_segment_entry(  # pylint: disable=too-many-arguments
             self, benchmark, fuzzer, trial_id, file_name, line, column, time):
         """Adds an entry to the segment_df."""
-        fuzzer_id = self.name_to_id(fuzzer)
-        benchmark_id = self.name_to_id(benchmark)
-        file_id = self.name_to_id(file_name)
-        self.fuzzer_names[fuzzer] = fuzzer_id
-        self.benchmark_names[benchmark] = benchmark_id
-        self.file_names[file_name] = file_id
-
         segment_entry = [
-            benchmark_id, fuzzer_id, trial_id, time, file_id, line, column
+            benchmark, fuzzer, trial_id, time, file_name, line, column
         ]
-        self.segment_entries.append(segment_entry)
 
-    def generate_data_frames_after_adding_all_entries(self):
-        """Generates the data frames from the individual entries."""
+        insert_series = pd.Series(segment_entry, index=self.segment_df.columns)
+        self.segment_df = self.segment_df.append(insert_series,
+                                                 ignore_index=True)
 
-        if len(self.segment_entries) == 0:
-            coverage_utils.logger.error(
-                'Finalizing, but no entries were added.')
-            return
-
-        self.segment_df = pd.DataFrame(self.segment_entries,
-                                       columns=[
-                                           'benchmark', 'fuzzer', 'trial',
-                                           'time', 'file', 'line', 'column'
-                                       ])
-        self.function_df = pd.DataFrame(self.function_entries,
-                                        columns=[
-                                            'benchmark', 'fuzzer', 'trial',
-                                            'time', 'function', 'hits'
-                                        ])
-
-        name_entries = []
-        for name in self.benchmark_names:
-            name_entries.append([self.benchmark_names[name], name, 'benchmark'])
-        for name in self.fuzzer_names:
-            name_entries.append([self.fuzzer_names[name], name, 'fuzzer'])
-        for name in self.function_names:
-            name_entries.append([self.function_names[name], name, 'function'])
-        for name in self.file_names:
-            name_entries.append([self.file_names[name], name, 'file'])
-        self.name_df = pd.DataFrame(name_entries,
-                                    columns=['id', 'name', 'type'])
-
-    def name_to_id(self, name):  # pylint: disable=no-self-use
-        """Generates a hash for the name. This is to save disk storage"""
-        return hashlib.md5(name.encode()).hexdigest()[:7]
-
-    def remove_redundant_entries(self):
-        """Removes redundant entries in segment_df. Before calling this
-        method, for each time stamp, segment_df contains all segments that are
-        covered in this time stamp. After calling this method, for each time
-        stamp, segment_df only contains segments that have been covered since
-        the previous time stamp. This significantly reduces the size of the
-        resulting CSV file."""
-        try:
-            # Drop duplicates but with different timestamps in segment data.
-            self.segment_df = self.segment_df.sort_values(by=['time'])
-            self.segment_df = self.segment_df.drop_duplicates(
-                subset=self.segment_df.columns.difference(['time']),
-                keep='first')
-            self.name_df = self.name_df.drop_duplicates(keep='first')
-
-        except (ValueError, KeyError, IndexError):
-            coverage_utils.logger.error(
-                'Error occurred when removing duplicates.')
-
-    def generate_csv_files(self):
+    def generate_csv_files(self, trial_specific_directory, trial_id, cycle):
         """Generates three compressed CSV files containing coverage information
         for all fuzzers, benchmarks, and trials. To maintain a small file size,
         all strings, such as file and function names, are referenced by id and
         resolved in 'names.csv'."""
 
-        # Clean and prune experiment-specific data frames.
-        self.remove_redundant_entries()
-
         # Write CSV files to filestore.
-        def csv_filestore_helper(file_name, df):
+        def csv_filestore_helper(file_name, df, file_type):
             """Helper method for storing csv files in filestore."""
-            src = os.path.join(coverage_utils.get_coverage_info_dir(), 'data',
-                               file_name)
+
+            if file_type == 'function':
+                src = os.path.join(trial_specific_directory, 'function',
+                                   file_name)
+            else:
+                src = os.path.join(trial_specific_directory, 'segments',
+                                   file_name)
+
             dst = exp_path.filestore(src)
             df.to_csv(src, index=False, compression='infer')
             filestore_utils.cp(src, dst)
 
-        csv_filestore_helper('functions.csv.gz', self.function_df)
-        csv_filestore_helper('segments.csv.gz', self.segment_df)
-        csv_filestore_helper('names.csv.gz', self.name_df)
+        csv_filestore_helper('functions_{trial_id}_{cycle}.csv.gz',
+                             self.function_df)
+        csv_filestore_helper('segments_{trial_id}_{cycle}.csv.gz',
+                             self.segment_df)
 
 
 def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-many-locals
@@ -184,5 +122,4 @@ def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-man
             'Failed when extracting trial-specific segment and function '
             'information from coverage summary.')
 
-    trial_specific_coverage_data.generate_data_frames_after_adding_all_entries()
     return trial_specific_coverage_data

--- a/experiment/measurer/test_detailed_coverage_data_utils.py
+++ b/experiment/measurer/test_detailed_coverage_data_utils.py
@@ -35,120 +35,32 @@ def get_test_data_path(*subpaths):
     return os.path.join(TEST_DATA_PATH, *subpaths)
 
 
-def test_data_frame_container_remove_redundant_entries(fs):
-    """Tests that remove_redundant_entries removes all duplicates entries in
-    name_df and segment_df."""
-
-    summary_json_file = get_test_data_path(SUMMARY_JSON_FILE)
-    fs.add_real_file(summary_json_file, read_only=False)
-
-    trial_specific_coverage_data = (
-        detailed_coverage_data_utils.
-        extract_segments_and_functions_from_summary_json(
-            summary_json_file, BENCHMARK, FUZZER, TRIAL_ID, TIMESTAMP))
-
-    # Check whether the length of the segment data frame is the same if we
-    # request pandas to drop all duplicates with the same time stamp
-    deduplicated = trial_specific_coverage_data.segment_df.drop_duplicates(
-        subset=trial_specific_coverage_data.segment_df.columns.difference(
-            ['time']))
-    old_length = len(trial_specific_coverage_data.segment_df)
-    assert old_length == len(deduplicated)
-
-
 def test_extract_segments_and_functions_from_summary_json_for_segments(fs):
     """Tests that segments and functions from summary json properly extracts the
      information and also test for integrity of fuzzer, benchmark and function
      ids in segment_df for a given summary json file."""
 
-    summary_json_file = get_test_data_path(SUMMARY_JSON_FILE)
+    summary_json_file = get_test_data_path('cov_summary.json')
     fs.add_real_file(summary_json_file, read_only=False)
+    trial_segment_functions_data = detailed_coverage_data_utils.\
+        extract_segments_and_functions_from_summary_json(summary_json_file,
+                                                         BENCHMARK, FUZZER,
+                                                         TRIAL_ID, TIMESTAMP)
 
-    trial_specific_coverage_data = (
-        detailed_coverage_data_utils.
-        extract_segments_and_functions_from_summary_json(
-            summary_json_file, BENCHMARK, FUZZER, TRIAL_ID, TIMESTAMP))
+    print(trial_segment_functions_data.segment_df)
+    print(trial_segment_functions_data.function_df)
 
-    fuzzer_ids = trial_specific_coverage_data.segment_df['fuzzer'].unique()
-    benchmark_ids = trial_specific_coverage_data.function_df[
-        'benchmark'].unique()
-    file_ids = trial_specific_coverage_data.segment_df['file'].unique()
-
-    # Assert length of resulting data frame is as expected.
-    assert len(trial_specific_coverage_data.segment_df
-              ) == NUM_COVERED_SEGMENTS_IN_COV_SUMMARY
-
-    # Assert integrity for fuzzer ids, types and names.
-    for fuzzer_id in fuzzer_ids:
-        integrity_check_helper(trial_specific_coverage_data, fuzzer_id,
-                               'fuzzer', FUZZER)
-
-    # Assert integrity for benchmark ids, types and names.
-    for benchmark_id in benchmark_ids:
-        integrity_check_helper(trial_specific_coverage_data, benchmark_id,
-                               'benchmark', BENCHMARK)
-
-    # Assert integrity for file ids.
-    for file_id in file_ids:
-        integrity_check_helper(trial_specific_coverage_data, file_id, 'file',
-                               FILE_NAME)
-
-
-def test_extract_segments_and_functions_from_summary_json_for_functions(fs):
-    """Tests that segments and functions from summary json properly extracts the
-     information and also test for integrity of fuzzer, benchmark and function
-     ids in function_df for a given summary json file.."""
-
-    summary_json_file = get_test_data_path(SUMMARY_JSON_FILE)
-    fs.add_real_file(summary_json_file, read_only=False)
-
-    trial_specific_coverage_data = (
-        detailed_coverage_data_utils.
-        extract_segments_and_functions_from_summary_json(
-            summary_json_file, BENCHMARK, FUZZER, TRIAL_ID, TIMESTAMP))
-
-    fuzzer_ids = trial_specific_coverage_data.function_df['fuzzer'].unique()
-    benchmark_ids = trial_specific_coverage_data.function_df[
-        'benchmark'].unique()
-    function_ids = trial_specific_coverage_data.function_df['function'].unique()
-
-    # Assert length of resulting data frame is as expected.
-    assert len(
-        trial_specific_coverage_data.function_df) == NUM_FUNCTION_IN_COV_SUMMARY
-
-    # Assert integrity for fuzzer ids, types and names.
-    for fuzzer_id in fuzzer_ids:
-        integrity_check_helper(trial_specific_coverage_data, fuzzer_id,
-                               'fuzzer', FUZZER)
-
-    # Assert integrity for benchmark ids, types and names.
-    for benchmark_id in benchmark_ids:
-        integrity_check_helper(trial_specific_coverage_data, benchmark_id,
-                               'benchmark', BENCHMARK)
-
-    # Assert integrity for function ids.
-    for function_id in function_ids:
-        integrity_check_helper(trial_specific_coverage_data, function_id,
-                               'function', FUNCTION_NAMES)
-
-
-def integrity_check_helper(trial_specific_coverage_data, _id, _type, name):
-    """Helper function to check the integrity of resulting
-    trial_specific_coverage_data after
-    recording segment and function information for the given id, type and
-    name."""
-
-    # Check whether the given id has the expected type.
-    assert (trial_specific_coverage_data.name_df[
-        trial_specific_coverage_data.name_df['id'] == _id]['type'].item() ==
-            _type)
-
-    if _type == 'function':
-        # check if all function names for each function id is already known.
-        assert (set(trial_specific_coverage_data.name_df[
-            trial_specific_coverage_data.name_df['id'] == _id]
-                    ['name'].unique()).issubset(name))
-    else:
-        # Check whether the given name resolves to the expected id.
-        assert (_id == trial_specific_coverage_data.name_df[
-            trial_specific_coverage_data.name_df['name'] == name]['id'].item())
+    assert len(trial_segment_functions_data.segment_df) \
+        == NUM_COVERED_SEGMENTS_IN_COV_SUMMARY
+    assert len(trial_segment_functions_data.function_df) \
+        == NUM_FUNCTION_IN_COV_SUMMARY
+    assert trial_segment_functions_data.function_df['benchmark'].unique(
+    )[0] == BENCHMARK
+    assert trial_segment_functions_data.function_df['fuzzer'].unique(
+    )[0] == FUZZER
+    assert trial_segment_functions_data.function_df['fuzzer'].unique(
+    )[0] == FUZZER
+    assert trial_segment_functions_data.segment_df['file'].unique() == FILE_NAME
+    for function_names in trial_segment_functions_data.function_df[
+            'function'].unique():
+        assert function_names in FUNCTION_NAMES


### PR DESCRIPTION
Changes made to detailed coverage utils and corresponding test cases for recording trial specific information in each cycle for segment and function coverage. 

1. We are not resolving to ids
2. Not using dicts, directly using data frames (since we are writing trial specific files in each cycle)
3. Unit tests have been update accordingly.

The changes with respect to save the files in GCS bucket will follow in a new PR :)